### PR TITLE
Rewrite structure of Init 

### DIFF
--- a/src/Init.php
+++ b/src/Init.php
@@ -2,21 +2,67 @@
 
 namespace BladeComponentLibrary;
 
-use \HelsingborgStad\GlobalBladeEngine as Blade;
+use HelsingborgStad\GlobalBladeEngine as Blade;
 
-class Init
-{
-    public function __construct()
-    {
-        //Add view path to renderer
-        Blade::addViewPath(__DIR__ . '/Component');
-
-        Register::addControllerPath(
-            __DIR__ . DIRECTORY_SEPARATOR . "Component" . DIRECTORY_SEPARATOR
+class Init {
+    public function __construct(
+        $paths = array(
+            'viewPaths' => array(),
+            'controllerPaths' => array(),
+            'internalComponentsPath' => array(),
+        )
+    ) {
+        // Add view path to renderer
+        // In this case all components, their controller and view path are located under the same folder structure.
+        // This may differ in a Wordpress child implementation.
+        $internalPaths = array(
+            __DIR__ . DIRECTORY_SEPARATOR . 'Component' . DIRECTORY_SEPARATOR,
         );
 
-        Register::registerInternalComponents(
-            __DIR__ . DIRECTORY_SEPARATOR . "Component" . DIRECTORY_SEPARATOR
+        // Initialize all view paths so that this library is last
+        $viewPaths = array_unique(
+            array_merge($paths['viewPaths'], $internalPaths)
         );
+        if (function_exists('apply_filters')) {
+            $viewPaths = apply_filters(
+                'helsingborg-stad/blade/viewPaths',
+                $viewPaths
+            );
+        }
+        foreach ($viewPaths as $path) {
+            Blade::addViewPath(rtrim($path, DIRECTORY_SEPARATOR));
+        }
+
+        // Initialize all controller paths so that this library is last
+        $controllerPaths = array_unique(
+            array_merge($paths['controllerPaths'], $internalPaths)
+        );
+        if (function_exists('apply_filters')) {
+            $controllerPaths = apply_filters(
+                'helsingborg-stad/blade/controllerPaths',
+                $controllerPaths
+            );
+        }
+        foreach ($controllerPaths as $path) {
+            Register::addControllerPath(
+                rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+            );
+        }
+
+        // Initialize all internal components paths so that this library is last
+        $internalComponentsPath = array_unique(
+            array_merge($paths['internalComponentsPath'], $internalPaths)
+        );
+        if (function_exists('apply_filters')) {
+            $internalComponentsPath = apply_filters(
+                'helsingborg-stad/blade/internalComponentsPath',
+                $internalComponentsPath
+            );
+        }
+        foreach ($internalComponentsPath as $path) {
+            Register::registerInternalComponents(
+                rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+            );
+        }
     }
 }


### PR DESCRIPTION
Using the `BladeComponentLibrary\Init` class to init this blade component library it will now gather all view paths and controller paths before running internal component registration.

**Related issue**: [issue 3](https://github.com/helsingborg-stad/blade-component-library/issues/3)

**Feature**: Integrate with a possible Wordpress scenario.

This rewrite was made due to limitations in `HelsingborgStad\GlobalBladeEngine` specifically the `instance()` where once called makes it impossible to add new view paths later on. 

Function `Register::registerInternalComponents($path)` makes several calls to the `GlobalBladeEngine`. The constructor will now build a list of all viewpaths, controller paths and component locations before making calls the the Blade engine