### PR TITLE
A complete rework of buttons.

### DIFF
--- a/src/Component/Button/Button.php
+++ b/src/Component/Button/Button.php
@@ -10,119 +10,84 @@ class Button extends \BladeComponentLibrary\Component\BaseController
         //Extract array for eazy access (fetch only)
         extract($this->data);
 
-        $this->data['id'] = uniqid("", true);
+		$this->data['id'] = uniqid("", true);
 
-        // Specific configuration depending on the button type
-        if ($isIconButton) {
-            $this->setIconButton($hover, $toggle, $color);
-        } elseif ($isOutlined) {
-            $this->setOutlinedButton($color, $toggle, $size);
-        } elseif ($isTextButton) {
-            $this->setTextButton($color, $size);
-        } else {
-            $this->setBackground($background);
-            $this->setSize($size);
-        }
+		$typeClass = '__' . $type;
+		$colorClass = '__' . $type . '--' . $color;
+	
+		$this->addToClassList(true, $typeClass, $colorClass);
+		$this->setSize($text, $icon, $size);
 
-        // General configuration
-        if ($reverseIcon) {
-            $this->reverseIcon();
-        }
-        
-        if ($floating) {
-            $this->setFloating($floating);
-        }
-    
-        if ($hasRipple) {
-            $this->setRipple();
-        }
-    }
-
-    private function setIconButton($hover, $toggle, $color)
+		if($toggle) $this->setToggleAttributes();
+		if($ripple) $this->setRipple();
+		if($reversePositions) $this->reversePositions();
+	}
+	
+	/**
+	 * Set attributes
+	 *
+	 * @return void
+	 */
+    private function setToggleAttributes()
     {
-		$this->addToClassList("__icon");
-
-        if ($toggle) {
-            $this->setToggleAttributes(true, $color);
-        }
-
-        if (isset($hover['background'])) {
-            $this->addToClassList('__icon-hover-background--' . $hover['background']);
-        }
-
-        if (isset($hover['color'])) {
-            $this->addToClassList('__icon-hover-color--' . $hover['color']);
-        }
+		$toggleId = uniqid('', true);
+		
+		if(!$this->data['attributeList']['js-toggle-trigger']){
+			$this->data['attributeList']['js-toggle-trigger'] = $toggleId;
+			$this->data['attributeList']['js-toggle-item'] = $toggleId;
+		}
+		
+		$this->addToClassList(true, '__toggle');
     }
 
-    private function setOutlinedButton($color, $toggle, $size)
+	/**
+	 * Add one or more classes to the classlist
+	 *
+	 * @param Boolean $prependBaseClass Option to prepend the base class(c-button)
+	 * @param Variadic ...$classList One or more css classes as strings
+	 * @return void
+	 */
+    private function addToClassList($prependBaseClass, ...$classList)
     {
-        $this->addToClassList("__outlined--" . $color);
-        $this->setSize($size);
+		foreach($classList as $class){
+			if($prependBaseClass) $class = $this->getBaseClass() . $class;
 
-        if ($toggle) {
-            $this->setToggleAttributes();
-        }
-    }
+			$this->data['classList'][] = $class;	
+		}
+	} 
 
-    private function setTextButton($color, $size)
+	/**
+	 * Set the size, different class depending on content
+	 *
+	 * @param String $text The buttons text
+	 * @param String $icon The name of the icon
+	 * @param String $size The size of the button(sm, md, lg)
+	 * @return void
+	 */
+	private function setSize($text, $icon, $size)
+	{
+		$class = (!$text && $icon) ? '__icon-size--' . $size : '--' . $size;
+
+		$this->addToClassList(true, $class);
+	}
+
+	/**
+	 * Set ripple animation on click
+	 *
+	 * @return void
+	 */
+	private function setRipple()
     {
-        $this->setSize($size);
-        $this->addToClassList('__text');
-        $this->addToClassList('__text--' . $color);
-    }
-    
-    // Give the button a floating effect, with or without animation
-    private function setFloating($floating)
-    {
-        if (isset($floating['animate']) && isset($floating['hover']) && $floating['animate'] && $floating['hover']) {
-            $this->addToClassList("--animated-float-on-hover");
-        } elseif (isset($floating['hover']) && $floating['hover']) {
-            $this->addToClassList("--float-on-hover");
-        }
-    }
-
-    // Set the background for any button except text and outlined
-    private function setBackground($background)
-    {
-		$this->addToClassList("--" . $background);
-    }
-
-    // Set size for all buttons except icon buttons
-    private function setSize($size)
-    {
-        $this->addToClassList("--" . $size);
-    }
-
-    // Apply ripple animation on click
-    private function setRipple()
-    {
-        $this->addToClassList("ripple", true);
-        $this->addToClassList("ripple--before", true);
-    }
-
-    // Reverse the icons position in relation to text
-    private function reverseIcon()
-    {
-        $this->data['labelMod'] = '--reverse';
-    }
-
-    // Sett data attributes if toggle is set to true on an icon button or an outlined button
-    private function setToggleAttributes($isIconButton = false, $color = false)
-    {
-        $toggleId = uniqid('', true);
-        $this->data['attributeList']['js-toggle-trigger'] = $toggleId;
-        $this->data['attributeList']['js-toggle-item'] = $toggleId;
-        
-
-        if ($isIconButton) {
-            $this->addToClassList('__icon-toggle--' . $color);
-        }
-    }
-
-    private function addToClassList($class, $withoutBaseClass = false)
-    {
-		$class = $withoutBaseClass ? $class : $this->getBaseClass() . $class;
-		$this->data['classList'][] = $class;
-    }
+		$this->addToClassList(false, 'ripple', 'ripple--before');
+	}
+	
+	/**
+	 * Reverse the positions of text and icon
+	 *
+	 * @return void
+	 */ 
+	private function reversePositions()
+	{
+		$this->data['labelMod'] = '--reverse';	
+	}
 }

--- a/src/Component/Button/button.blade.php
+++ b/src/Component/Button/button.blade.php
@@ -1,23 +1,24 @@
 <{{$componentElement}} id="{{ $id }}" class="{{ $class }}" target="{{ $target }}" aria-pressed="{{$pressed}}" href="{{ $href }}" {!! $attribute !!}>   
     <{{$labelElement}} class="{{$baseClass}}__label">
-        @if($isIconButton)
-            @icon(['icon' => $icon['name'], 'color' => $icon['color'], 'size' => $size, 
-            'classList' => array("u-rounded--full")])
+       
+        @if($text && $icon)
+            <span class="{{$baseClass}}__label-text{{$labelMod}}">
+                {{$text}}
+            </span>
+
+            <span class="{{$baseClass}}__label-icon{{$labelMod}}">
+                @icon(['icon' => $icon])
+                @endicon
+            </span>
+        @elseif($text && !$icon)
+            <span class="{{$baseClass}}__label-text{{$labelMod}}">
+                {{$text}}
+            </span>
+        @elseif($icon && !$text)
+            @icon(['icon' => $icon])
             @endicon
-        @elseif($icon)
-                <span class="{{$baseClass}}__label-text{{$labelMod}}">
-                    {{$text}}
-                </span>
-                <span class="{{$baseClass}}__label-icon{{$labelMod}}">
-                    @icon(
-                        ['icon' => $icon['name']]
-                    )
-                    @endicon
-                </span>
-        @else
-            {{$text}}
         @endif
-        
+
         @if ($slot)
             {{ $slot }}
         @endif

--- a/src/Component/Button/button.json
+++ b/src/Component/Button/button.json
@@ -3,18 +3,15 @@
 {
    "slug":"button",
    "default":{
-      "text": "Button",
+      "text": false,
       "size": "md",
-      "color": "primary",
+      "color": "default",
+      "type": "filled",
       "href":"#",
-      "background": false,
       "target":"_top",
       "componentElement":"button",
       "labelElement":"span",
-      "isOutlined":false,
-      "isTextButton": false,
-      "isIconButton": false,
-      "hasRipple":false,
+      "ripple":false,
       "pressed": "false",
       "toggle": false,
       "floating": false,
@@ -22,7 +19,9 @@
       "icon": false,
       "reverseIcon": false,
       "hover": {"background": "default"},
-      "labelMod": ""
+      "labelMod": "",
+      "attributeList": {"js-toggle-trigger": "", "js-toggle-item": ""},
+      "reversePositions": false
    },
    "description":{
       "isOutlined":"Removes any background set on the button and sets text, border and background on hover to be the same color.",


### PR DESCRIPTION
An attempt at making the configuration of buttons
make more sense without any type-specific parameters.

 - Types
   - Basic, no background or border, only text
   - Outlined, border and text have same color
   - Filled, border and background

 - Toggle
   - If set to true default styling will be applied
   - If aria-pressed, the text color will be set to primary

 - Size
   - Regular, nothing new
   - Icons get specific sizes for both button and text

 - Floating buttons are now deleted

 - Icon hover color is also a thing of the past