### PR TITLE
Feedback: Municipio

### DIFF
--- a/src/Component/Signature/Signature.php
+++ b/src/Component/Signature/Signature.php
@@ -19,5 +19,12 @@ class Signature extends \BladeComponentLibrary\Component\BaseController
 		} else {
 			$this->data['componentElement'] = "div"; 
         }
+
+        //Labels
+        $this->data['label'] = (object) [
+            'publish' => $publishedLabel,
+            'updated' => $updatedLabel
+        ]; 
+
     }
 }

--- a/src/Component/Signature/signature.blade.php
+++ b/src/Component/Signature/signature.blade.php
@@ -11,6 +11,7 @@
         
         @if($author)
             @typography([
+                "element" => "span",
                 "variant" => "subtitle",
                 "classList" => [
                     $baseClass.'__author'
@@ -22,6 +23,7 @@
 
         @if($authorRole && $author) 
             @typography([
+                "element" => "span",
                 "variant" => "byline",
                 "classList" => [
                     $baseClass.'__title'
@@ -33,23 +35,25 @@
 
         @if ($published)
             @typography([
+                "element" => "span",
                 "variant" => "byline",
                 "classList" => [
                     $baseClass.'__published'
                 ]
             ])
-                Published: @date(['action' => 'formatDate','timestamp' => $published])@enddate
+                {{$label->publish}}: @date(['action' => 'formatDate','timestamp' => $published])@enddate
             @endtypography
         @endif
 
         @if ($updated)
             @typography([
+                "element" => "span",
                 "variant" => "byline",
                 "classList" => [
                     $baseClass.'__updated'
                 ]
             ])
-                Updated: @date(['action' => 'formatDate','timestamp' => $updated])@enddate
+                {{$label->updated}}: @date(['action' => 'formatDate','timestamp' => $updated])@enddate
             @endtypography
         @endif
     </div>

--- a/src/Component/Signature/signature.json
+++ b/src/Component/Signature/signature.json
@@ -7,7 +7,9 @@
         "avatar_size": "md",
         "published": "",
         "updated": "",
-        "link": ""
+        "link": "",
+        "updatedLabel": "Updated", 
+        "publishedLabel": "Published"
     },
     "description":{
         "author": "The name of the  author",
@@ -16,7 +18,9 @@
         "avatar_size": "Size of the avatar",
         "published": "A formatted published date",
         "updated": "A formatted update date",
-        "link": "Links the whole component to another place."
+        "link": "Links the whole component to another place.",
+        "updatedLabel": "Label text updated.", 
+        "publishedLabel": "Label text published."
     },
     "view":"signature.blade.php"
  }


### PR DESCRIPTION
Makes publish and updated labels translatable in signature component. Changes p-elements to span element to avoid being styles by theme & article component. 